### PR TITLE
fix console error with TexField propTypes

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -170,7 +170,7 @@ TextField.propTypes = {
   autoGrow: PropTypes.bool,
   duration: PropTypes.number,
   height: PropTypes.oneOfType([
-    PropTypes.oneOf(undefined),
+    undefined,
     PropTypes.number
   ]),
   helperText: PropTypes.string,


### PR DESCRIPTION
Current PropType causes this error:

![screen shot 2017-09-22 at 9 08 16 am 9 22 40 am](https://user-images.githubusercontent.com/12119980/30760784-2d207176-9fa1-11e7-8bd5-22703701f73f.png)


This change makes the error go away.
